### PR TITLE
Use urlpath for the Voila dashboard on Binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # covid-19-world-dashboard
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/sunnysinghnitb/covid-19-world-dashboard/master?filepath=%2Fvoila%2Frender%2Fcovid_19_dashboard.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/sunnysinghnitb/covid-19-world-dashboard/master?urlpath=%2Fvoila%2Frender%2Fcovid_19_dashboard.ipynb)
 
 Interactive visualizations of the impact of covid-19 around the world


### PR DESCRIPTION
Thanks for this cool dashboard!

Here is a small fix to get the Voila dashboard to show on Binder when using the link in the README.